### PR TITLE
Pushed updates after apt-get upgrade.  That hosed GLADEVCP and the

### DIFF
--- a/theshiz.ini
+++ b/theshiz.ini
@@ -17,7 +17,7 @@ NCAM_DIR = ncam
 #GLADEVCP = -U --catalog=mill ncam.ui
 #GLADEVCP= -u hitcounter.py manual-example.ui
 EMBED_TAB_NAME=NCAM
-EMBED_TAB_COMMAND=halcmd loadusr -Wn gladevcp gladevcp -c gladevcp -x {XID} -U --catalog=mill ncam.ui
+#EMBED_TAB_COMMAND=halcmd loadusr -Wn gladevcp gladevcp -c gladevcp -x {XID} -U --catalog=mill ncam.ui
 
 DISPLAY = axis
 EDITOR = gedit
@@ -30,7 +30,7 @@ MIN_SPINDLE_OVERRIDE = 0.2
 MAX_SPINDLE_OVERRIDE = 2.0
 DEFAULT_LINEAR_VELOCITY = 0.40
 MIN_LINEAR_VELOCITY = 0
-MAX_LINEAR_VELOCITY = 1.2
+MAX_LINEAR_VELOCITY = 0.75 
 DEFAULT_ANGULAR_VELOCITY = 36.00
 MIN_ANGULAR_VELOCITY = 0
 MAX_ANGULAR_VELOCITY = 360.00
@@ -57,7 +57,8 @@ CYCLE_TIME = 0.010
 
 [RS274NGC]
 # required NativeCAM item :
-SUBROUTINE_PATH = ncam/my-stuff:ncam/lib/mill:ncam/lib/utilities:ncam/lib/mill:ncam/lib/utilities:/home/wortley/linuxcnc/nc_files:~/Documents/jobs:
+SUBROUTINE_PATH = ncam/my-stuff:ncam/lib/mill:ncam/lib/utilities:ncam/lib/mill:ncam/lib/utilities:/home/wortley/linuxcnc/nc_files:~/Documents/jobs:~/Documents/irontools/ncfiles/
+USER_M_PATH = ~/Documents/irontools/ncfiles/
 
 
 PARAMETER_FILE = linuxcnc.var
@@ -89,7 +90,7 @@ LINEAR_UNITS = inch
 ANGULAR_UNITS = degree
 CYCLE_TIME = 0.010
 DEFAULT_VELOCITY = 36.00
-MAX_VELOCITY = 4.00
+MAX_VELOCITY = 1.00
 
 [EMCIO]
 EMCIO = io
@@ -119,9 +120,9 @@ HOME_FINAL_VEL = 0.75
 [AXIS_1]
 
 TYPE = LINEAR
-MAX_VELOCITY = 1.2
-MAX_ACCELERATION = 7.0
-STEPGEN_MAXACCEL = 7.9
+MAX_VELOCITY = 0.8
+MAX_ACCELERATION = 5.0
+STEPGEN_MAXACCEL = 5.9
 SCALE = 10000.0
 FERROR = 0.005
 MIN_FERROR = 0.001
@@ -134,7 +135,7 @@ HOME_LATCH_VEL = 0.005
 HOME_OFFSET = 15
 HOME = 12.982  
 HOME_USE_INDEX = NO
-HOME_FINAL_VELOCITY = 0.5
+HOME_FINAL_VELOCITY = 0.3
 
 [AXIS_2]
 

--- a/tool.tbl
+++ b/tool.tbl
@@ -1,5 +1,5 @@
 T1 P1 D0.200000 ;edge finder 
-T2 P2 D0.125000 Z-0.312801 ;1/8 flat er holder 
+T2 P2 D0.125000 Z-0.369227 ;1/8 flat er holder 
 T3 P3 D0.750000 Z-0.153099 ;center drill 0.25x0.75 
 T4 P4 D4.000000 ;face mill 
 T6 P6 D0.290000 Z+0.036302 ;threadmill 
@@ -8,7 +8,7 @@ T20 P20 D0.500000 ;countersink 0.5in 90deg
 T21 P21 D1.000000 ;1in end mill 
 T22 P22 D3.000000 ;3in shell mill 
 T7 P7 D0.875000 Z+0.999000 ;tap holder 
-T8 P8 D0.125000 Z-0.475698 ;0.125 60 degree chamfer bit 
+T8 P8 D0.125000 Z-0.476598 ;0.125 60 degree chamfer bit 
 T9 P9 D0.375000 Z+2.734410 ;drill chuck 
 T12 P12 D0.500000 Z+0.019610 ;1/2 3 flute carbide 
 T23 P23 D0.312500 Z-0.507977 ;5/16 ball mill 
@@ -17,3 +17,4 @@ T13 P13 D0.500000 ;.5 endmill
 T10 P10 D0.250000 Z+0.121121 ;0.25 3fl carbide x 0.75 
 T15 P15 D0.312500 Z+0.059667 ;5/16 drill mill 
 T18 P18 D0.375000 Z-0.117557 ;0.375 x 90 mill drill 4 fl 
+T19 P19 D0.062500 Z-0.233644 ;1/16 flat end mill 


### PR DESCRIPTION
ncam installation.  
This is the branch with the homing offsets in the control panel.
updated the tool.tbl with the 1/16th cutter.